### PR TITLE
chore: transfer @koba04/create-kintone-plugin to @kintone/create-plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Toru Kobayashi
+Copyright (c) 2018 Cybozu, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # create-kintone-plugin
 
-[![npm version](https://badge.fury.io/js/%40koba04%2Fcreate-kintone-plugin.svg)](https://badge.fury.io/js/%40koba04%2Fcreate-kintone-plugin)
-[![CircleCI](https://circleci.com/gh/koba04/create-kintone-plugin.svg?style=shield)](https://circleci.com/gh/koba04/create-kintone-plugin)
+[![npm version](https://badge.fury.io/js/%40kintone%2Fcreate-plugin.svg)](https://badge.fury.io/js/%40kintone%2Fcreate-plugin)
+[![CircleCI](https://circleci.com/gh/kintone/create-plugin.svg?style=shield)](https://circleci.com/gh/kintone/create-plugin)
 [![Build status](https://ci.appveyor.com/api/projects/status/emvyvmk1vd4rwbef?svg=true)](https://ci.appveyor.com/project/koba04/create-kintone-plugin)
 
 A CLI tool for creating a kintone plugin!
@@ -9,14 +9,7 @@ A CLI tool for creating a kintone plugin!
 ## Usage
 
 ```
-npx create-kintone-plugin ${name}
-```
-
-or
-
-```
-npm install -g create-kintone-plugin
-create-kintone-plugin ${name}
+npx @kintone/create-plugin ${name}
 ```
 
 After the command has been finished, you can start development kintone plugin!
@@ -28,15 +21,15 @@ npm start
 
 ## Language
 
-`create-kintone-plugin` is supporting Japanese,
+`@kintone/create-plugin` is supporting Japanese,
 if you want to use console messages in Japanese, you can use `--lang ja` option.
 
 ```
-npx create-kintone-plugin ${name} --lang ja
+npx @kintone/create-plugin ${name} --lang ja
 ```
 
 If you set `LANG` environment variable `ja_XX.XXX`, the lang option will be `ja` automatically.
 
 ## LICENSE
 
-MIT License: Toru Kobayashi
+MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@koba04/create-kintone-plugin",
+  "name": "@kintnoe/create-plugin",
   "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@koba04/create-kintone-plugin",
+  "name": "@kintone/create-plugin",
   "version": "0.5.5",
   "description": "A CLI tool for creating a kintone plugin!",
   "bin": "bin/cli.js",
@@ -7,6 +7,9 @@
   "engines": {
     "node": ">=6"
   },
+  "repository": "kintone/create-plugin",
+  "homepage": "https://github.com/kintone/create-plugin",
+  "bugs": "https://github.com/kintone/create-plugin/issues",
   "dependencies": {
     "chalk": "^2.4.1",
     "glob": "^7.1.2",
@@ -53,6 +56,6 @@
   "keywords": [
     "kintone"
   ],
-  "author": "koba04",
+  "author": "kintone",
   "license": "MIT"
 }


### PR DESCRIPTION
BREAKING CHANGE: The GitHub repository and the npm package are now kintone from koba04